### PR TITLE
Workaround for failed build due to openjdk upstream bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,15 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.1</version>
+				<configuration>
+					<!-- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 -->
+					<useSystemClassLoader>false</useSystemClassLoader>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-scm-plugin</artifactId>
 				<version>1.9.4</version>
 				<configuration>


### PR DESCRIPTION
```
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter
```