### PR TITLE
Migrate IBAN validation to iban-commons

### DIFF
--- a/common-dto/pom.xml
+++ b/common-dto/pom.xml
@@ -17,10 +17,11 @@
 			<version>2.0.1.Final</version>
 			<optional>true</optional>
 		</dependency>
+		<!-- iban-commons: Zero-dependency, high-performance Java 8+ IBAN and BIC validation library -->
 		<dependency>
-			<groupId>org.iban4j</groupId>
-			<artifactId>iban4j</artifactId>
-			<version>3.2.13-RELEASE</version>
+			<groupId>de.speedbanking</groupId>
+			<artifactId>iban-commons</artifactId>
+			<version>1.8.7</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/common-dto/src/main/java/com/liberologico/cloudesire/common/validators/IBANValidatorForString.java
+++ b/common-dto/src/main/java/com/liberologico/cloudesire/common/validators/IBANValidatorForString.java
@@ -1,6 +1,6 @@
 package com.liberologico.cloudesire.common.validators;
 
-import org.iban4j.IbanUtil;
+import de.speedbanking.iban.Iban;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -16,19 +16,6 @@ public class IBANValidatorForString implements ConstraintValidator<IBAN, String>
     @Override
     public boolean isValid( String iban, ConstraintValidatorContext context )
     {
-        if ( iban == null )
-        {
-            return true;
-
-        }
-        try
-        {
-            IbanUtil.validate( iban );
-        }
-        catch ( Exception e )
-        {
-            return false;
-        }
-        return true;
+        return iban == null || Iban.isValid(iban);
     }
 }


### PR DESCRIPTION
This PR introduces `iban-commons` in favor of `iban4j`. [`iban-commons`](https://www.speedbanking.de/) has demonstrated to be superior in terms of performance, allocation (GC pressure), country coverage etc.
The internal validation logic in `IBANValidatorForString` has been refactored for better performance and readability.

- replace iban4j dependency with iban-commons v1.8.6
- update IBANValidatorForString to use de.speedbanking.iban.Iban
- simplify isValid logic using short-circuit evaluation

I am an author of the `iban-commons` library ([GitHub](https://github.com/SpeedBankingDe/iban-commons)).